### PR TITLE
CartesianRange instead of cartesianmap on Julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3-
+julia 0.3
 Compat

--- a/src/block_framework.jl
+++ b/src/block_framework.jl
@@ -178,11 +178,18 @@ function Block(A::Array, dims::Array=[])
         numblocks = *(itershape...)
         blks = cell(numblocks)
         blkid = 1
-        cartesianmap(itershape) do idxs...
-            ia = [idxs...]
-            idx[otherdims] = ia
-            blks[blkid] = reshape(A[idx...], Asliceshape)
-            blkid += 1
+        if VERSION >= v"0.4.0-dev+3184"
+            for idxs in CartesianRange(itershape)
+                idx[otherdims] = [idxs[i] for i in 1:length(idxs)]
+                blks[blkid] = reshape(A[idx...], Asliceshape)
+                blkid += 1
+            end
+        else
+            cartesianmap(itershape) do idxs...
+                idx[otherdims] = [idxs...]
+                blks[blkid] = reshape(A[idx...], Asliceshape)
+                blkid += 1
+            end
         end
     end
     Block(A, blks, no_affinity, as_it_is, as_it_is)


### PR DESCRIPTION
- switch to `CartesianRange` instead of deprecated `cartesianmap` on Julia 0.4
- remove support for pre-release Julia 0.3