### PR TITLE
adapt to Julia 0.4/0.5, add matrix block abstractions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4-rc1
 Compat

--- a/src/Blocks.jl
+++ b/src/Blocks.jl
@@ -4,15 +4,19 @@ using Base.FS
 using Compat
 
 importall   Base
-import      Base: peek, throwto, AsyncStream, open
+import      Base: peek, throwto, open
 
 if isless(Base.VERSION, v"0.4.0-")
-import      Base.localpart
+import      Base: AsyncStream, localpart
+typealias LibuvStream AsyncStream
+elseif isless(Base.VERSION, v"0.5.0-")
+import      Base: AsyncStream, |>
+typealias LibuvStream AsyncStream
 else
-import      Base.|>
+import      Base: LibuvStream, |>
 end
 
-export      Block, |>, .>, prepare, @prepare, BlockableIO,
+export      Block, |>, prepare, @prepare, BlockableIO,
             blocks, affinities, localpart,
             as_it_is, as_io, as_recordio, as_wordio, as_lines, as_bufferedio, as_bytearray,
 

--- a/src/block_framework.jl
+++ b/src/block_framework.jl
@@ -1,4 +1,4 @@
-typealias BlockableIO Union(IOStream,AsyncStream,IOBuffer,BlockIO)
+typealias BlockableIO Union{IOStream,LibuvStream,IOBuffer,BlockIO}
 
 type Block{T}
     source::T
@@ -19,18 +19,18 @@ as_it_is(x) = x
 as_io(x) = open(x)
 as_io(f::File) = open(f.path)
 function as_io(x::Tuple)
-    if isa(x[1], AsyncStream)
+    if isa(x[1], LibuvStream)
         aio = x[1]
         maxsize = x[2]
         start_reading(aio)
         Base.wait_readnb(aio, maxsize)
         avlb = min(nb_available(aio.buffer), maxsize)
-        return PipeBuffer(read(aio, Array(Uint8,avlb)))
+        return PipeBuffer(read(aio, Array(UInt8,avlb)))
     elseif isa(x[1], BlockableIO)
         io = x[1]
         # using BlockIO to avoid copy.
         # but since BlockIO would skip till the first record delimiter,
-        # we must present it the last read byte (which must be the last read delimiter)
+        # we must present to it the last read byte (which must be the last read delimiter)
         # therefore we pass the last read position as the start position for BlockIO
         pos = position(io)
         endpos = pos+x[2]
@@ -41,24 +41,24 @@ function as_io(x::Tuple)
     end
 end
 function as_bufferedio(x::BlockableIO)
-    buff = read(x, Array(Uint8, nb_available(x)))
+    buff = read(x, Array(UInt8, nb_available(x)))
     close(x)
     IOBuffer(buff)
 end
 as_lines(x::BlockableIO) = readlines(x)
-as_bytearray(x::BlockableIO) = read(x, Array(Uint8, nb_available(x)))
+as_bytearray(x::BlockableIO) = read(x, Array(UInt8, nb_available(x)))
 
 as_recordio(x::BlockIO, dlm::Char='\n') = BlockIO(x, dlm)
 function as_recordio(x::Tuple)
     dlm = (length(x) == 3) ? x[3] : '\n'
-    if isa(x[1], AsyncStream)
+    if isa(x[1], LibuvStream)
         aio = x[1]
         minsize = x[2]
         start_reading(aio)
         Base.wait_readnb(aio, minsize)
         tot_avlb = nb_available(aio.buffer)
         avlb = min(tot_avlb, minsize)
-        pb = PipeBuffer(read(aio, Array(Uint8,avlb)))
+        pb = PipeBuffer(read(aio, Array(UInt8,avlb)))
         write(pb, readuntil(aio, dlm))
         return pb
     else
@@ -76,7 +76,6 @@ function filter(f::Function, b::Block)
     end
 end
 
-.>(b::Block, f::Function) = prepare(b, f)
 function prepare(b::Block, f::Function)
     let oldf = b.prepare
         b.prepare = (x)->f(oldf(x))
@@ -206,7 +205,7 @@ function Block(f::File, nsplits::Int=0)
 end
 
 function Block(f::File, recurse::Bool=true, nfiles_per_split::Int=0)
-    files = String[]
+    files = AbstractString[]
     all_files(f.path, recurse, files)
 
     data = Any[]
@@ -229,7 +228,7 @@ Block{T<:BlockableIO}(aio::T, approxsize::Int, dlm::Char) = Block(aio, [(aio,app
 
 ##
 # utility methods
-function all_files(path::String, recurse::Bool, list::Array)
+function all_files(path::AbstractString, recurse::Bool, list::Array)
     files = readdir(path)
 
     for file in files

--- a/src/block_io.jl
+++ b/src/block_io.jl
@@ -8,18 +8,18 @@ immutable BlockIO <: IO
     function find_end_pos(bio::BlockIO, end_byte::Char)
         seekend(bio)
         try
-            while(!eof(bio.s) && (end_byte != read(bio, Uint8))) continue end
+            while(!eof(bio.s) && (end_byte != read(bio, UInt8))) continue end
         end
         position(bio.s)
     end
     function find_start_pos(bio::BlockIO, end_byte::Char)
         (bio.r.start == 1) && (return bio.r.start)
         seekstart(bio)
-        !eof(bio.s) && while(end_byte != read(bio, Uint8)) continue end
+        !eof(bio.s) && while(end_byte != read(bio, UInt8)) continue end
         position(bio.s)+1
     end
 
-    function BlockIO(s::IO, r::UnitRange, match_ends::Union(Char,Nothing)=nothing)
+    function BlockIO(s::IO, r::UnitRange, match_ends::Union{Char,Void}=nothing)
         # TODO: use mark when available
         seekend(s)
         ep = position(s)
@@ -37,20 +37,21 @@ immutable BlockIO <: IO
     end
 end
 
-BlockIO(bio::BlockIO, match_ends::Union(Char,Nothing)=nothing) = BlockIO(bio.s, bio.r, match_ends)
+BlockIO(bio::BlockIO, match_ends::Union{Char,Void}=nothing) = BlockIO(bio.s, bio.r, match_ends)
 
 close(bio::BlockIO) = close(bio.s)
 eof(bio::BlockIO) = (position(bio) >= bio.l)
-read(bio::BlockIO, x::Type{Uint8}) = read(bio.s, x)
+read(bio::BlockIO, x::Type{UInt8}) = read(bio.s, x)
+read!(bio::BlockIO, a::Vector{UInt8}) = (length(a) <= nb_available(bio)) ? read!(bio.s, a) : throw(EOFError())
 read!{T}(bio::BlockIO, a::Array{T}) = (length(a)*sizeof(T) <= nb_available(bio)) ? read!(bio.s, a) : throw(EOFError())
 
-readbytes(bio::BlockIO, nb::Integer) = bytestring(read!(bio, Array(Uint8, nb)))
+readbytes(bio::BlockIO, nb::Integer) = bytestring(read!(bio, Array(UInt8, nb)))
 readall(bio::BlockIO) = readbytes(bio, nb_available(bio))
 
 peek(bio::BlockIO) = peek(bio.s)
 write(bio::BlockIO, p::Ptr, nb::Integer) = write(bio, p, int(nb))
 write(bio::BlockIO, p::Ptr, nb::Int) = write(bio.s, p, nb)
-write(bio::BlockIO, x::Uint8) = write(bio, Uint8[x])
+write(bio::BlockIO, x::UInt8) = write(bio, UInt8[x])
 write{T}(bio::BlockIO, a::Array{T}, len) = write_sub(bio, a, 1, len)
 write{T}(bio::BlockIO, a::Array{T}) = write(bio, a, length(a))
 write_sub{T}(bio::BlockIO, a::Array{T}, offs, len) = isbits(T) ? write(bio, pointer(a,offs), len*sizeof(T)) : error("$T is not bits type")

--- a/src/pmap.jl
+++ b/src/pmap.jl
@@ -82,7 +82,7 @@ end
 ##
 # generic map on any iterator
 #
-#function map(f::Union(Function,DataType), iters...)
+#function map(f::Union{Function,DataType}, iters...)
 #    result = {}
 #    len = length(iters)
 #    states = [start(iters[idx]) for idx in 1:len]

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,9 +1,10 @@
 using Blocks
+using Compat
 
 const datafile = joinpath(dirname(@__FILE__), "test.csv")
 const nloops = 10
 
-function testfn(f::Function, s::String, exp_res)
+function testfn(f::Function, s::AbstractString, exp_res)
     println("\t$(s)...")
     ret = f()
     println("\t\tresult: $(ret)")

--- a/test/test_matop.jl
+++ b/test/test_matop.jl
@@ -53,6 +53,42 @@ function do_mul_large()
     println("times: local:$t2 parallel:$t1")
 end
 
+function do_mul_test()
+    a1 = rand(10000, 2000)
+    a2 = rand(2000, 1)
+
+    mb = MatOpBlock(a1, a2, :*, NPROCS)
+    blk = Block(mb)
+    println("running matrix operation...")
+    t1 = @elapsed (result = op(blk))
+    println("times: parallel:$t1")
+end
+
+function do_rand_mul()
+    println("creating initial data...")
+    a1 = RandomMatrix(Float64, (24000, 24000), 0)
+    a2 = RandomMatrix(Float64, (24000, 1), 0)
+
+    println("making blocks...")
+    mb = MatOpBlock(a1, a2, :*, NPROCS)
+    blk = Block(mb)
+    println("running matrix operation...")
+    t1 = @elapsed (result = op(blk))
+    #t2 = 0
+    #rmprocs(workers())
+
+    println("calculating locally...")
+    la1 = convert(DenseMatrix, mb.ms1)
+    la2 = convert(DenseMatrix, mb.ms2)
+    t2 = @elapsed (tr = la1*la2)
+
+    println("verifying...")
+    @test_approx_eq tr result
+
+    println("times: local:$t2 parallel:$t1")
+end
+
+
 println("adding $NPROCS more processors...")
 addprocs(NPROCS)
 println("\tnprocs: $(nprocs())")
@@ -60,4 +96,5 @@ load_pkgs()
 
 do_mul()
 #do_mul_large()
-
+#do_mul_test()
+#do_rand_mul()

--- a/test/test_matop.jl
+++ b/test/test_matop.jl
@@ -1,13 +1,6 @@
-const NPROCS = isempty(ARGS) ? 3 : int(ARGS[1])
+using Base.Test
+const NPROCS = isempty(ARGS) ? 4 : int(ARGS[1])
 
-
-function load_pkgs()
-    println("loading packages...")
-    @everywhere using Blocks
-    @everywhere using Blocks.MatOp
-    #@everywhere using Base.FS
-    #@everywhere using DataFrames
-end
 
 function do_mul()
     println("creating initial data...")
@@ -26,15 +19,15 @@ function do_mul()
     t2 = @elapsed (tr = a3*a4)
 
     println("verifying...")
-    @assert all(tr .== result)
+    @test_approx_eq tr result
 
     println("times: local:$t2 parallel:$t1")
 end
 
 function do_mul_large()
     println("creating initial data...")
-    a1 = reshape([[1:5000;],[1:5000;]], 1, 10000)
-    a2 = reshape([[1:3000;],[1:3000;]], 6000, 1)
+    a1 = reshape([[1:5000;];[1:5000;]], 1, 10000)
+    a2 = reshape([[1:3000;];[1:3000;]], 6000, 1)
     a3 = a2*a1
     a4 = a3'
 
@@ -48,7 +41,7 @@ function do_mul_large()
     t2 = @elapsed (tr = a3*a4)
 
     println("verifying...")
-    @assert all(tr .== result)
+    @test_approx_eq tr result
 
     println("times: local:$t2 parallel:$t1")
 end
@@ -92,7 +85,9 @@ end
 println("adding $NPROCS more processors...")
 addprocs(NPROCS)
 println("\tnprocs: $(nprocs())")
-load_pkgs()
+println("loading packages...")
+using Blocks
+using Blocks.MatOp
 
 do_mul()
 #do_mul_large()


### PR DESCRIPTION
- Adapt to Julia 0.4 and 0.5 and update Julia version requirement to 0.4
- Introduce some abstractions for matrices to allow different ways of representing block matrices

Added simple implementations for RandomMatrix and in-memory DenseMatrix as examples/tests.